### PR TITLE
Allow T1OO access in frequency SQL

### DIFF
--- a/analysis/extract_covid_vaccination_name_frequency.sql
+++ b/analysis/extract_covid_vaccination_name_frequency.sql
@@ -1,3 +1,5 @@
+-- We don't query either patient-level or event-level data, so we need not
+-- exclude T1OOs using the AllowedPatientsWithTypeOneDissent table.
 SELECT
     VaccinationName_ID,
     VaccinationName,


### PR DESCRIPTION
It's already allowed in the vaccination name SQL, include the relevant comment in the frequecy count SQL too.